### PR TITLE
Allow CytoFrameView to be empty (flat in a dimension)

### DIFF
--- a/inst/include/cytolib/CytoFrameView.hpp
+++ b/inst/include/cytolib/CytoFrameView.hpp
@@ -16,12 +16,15 @@ class CytoFrameView{
 	CytoFramePtr ptr_;
 	arma::uvec row_idx_;
 	arma::uvec col_idx_;
+	bool is_row_indexed_ = false;
+	bool is_col_indexed_ = false;
 public:
 	CytoFrameView(){};
 	CytoFrameView(CytoFramePtr ptr):ptr_(ptr){};
 	CytoFramePtr get_cytoframe_ptr() const;
-	bool is_row_indexed() const{return row_idx_.size()>0;};
-	bool is_col_indexed() const{return col_idx_.size()>0;};
+	bool is_row_indexed() const{return is_row_indexed_;};
+	bool is_col_indexed() const{return is_col_indexed_;};
+	bool is_empty() const{return (is_row_indexed_ && row_idx_.is_empty()) || (is_col_indexed_ && col_idx_.is_empty());};
 
 	/*forwarded apis
 	 *
@@ -168,7 +171,7 @@ public:
 	void reset_view(){
 		row_idx_.clear();
 		col_idx_.clear();
-
+		is_row_indexed_ = is_col_indexed_ = false;
 	}
 	/**
 	 * Realize the delayed subsetting (i.e. cols() and rows()) operations to the underlying data
@@ -176,7 +179,12 @@ public:
 	 */
 	CytoFrameView copy_realized(const string & h5_filename = "") const
 	{
-		return get_cytoframe_ptr()->copy_realized(row_idx_, col_idx_, h5_filename);;
+		if(is_empty()){
+			// Force copy_realized to hit case yielding simple copy by making sure BOTH uvecs are empty
+			return get_cytoframe_ptr()->copy_realized(arma::uvec(), arma::uvec(), h5_filename);
+		}else{
+			return get_cytoframe_ptr()->copy_realized(row_idx_, col_idx_, h5_filename);	
+		}
 	}
 	void set_data(const EVENT_DATA_VEC & data_in);
 	EVENT_DATA_VEC get_data() const;


### PR DESCRIPTION
@mikejiang, I'm just making this a pull request to get another set of eyes on it before I merge it in. It's pretty straightforward. If a `CytoFrameView` is non-empty (has non-zero expanse in both dimensions), the behavior should be the same as before. But allowing it to be empty addresses the zero-event population problem of #22. After rebuilding `flowCore`, `flowWorkspace`, and `CytoML`, all tests are passing and the zero-event population error does not occur.