### PR TITLE
bug: fix build on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 # Copyright 2019 Fred Hutchinson Cancer Research Center
 # See the included LICENSE file for details on the licence that is granted to the user of this software.
-CXX_STD = CXX11
+CXX_STD = CXX17
 # Just a snippet to stop executing under other make(1) commands
 # that won't understand these lines
 ifneq (,)
@@ -18,7 +18,8 @@ PKG_CPPFLAGS =-DROUT -I../inst/include -DRCPP_PARALLEL_USE_TBB=1 -fpermissive -D
 	
 #needs to wrap in $(shell) to strip the quotes returned by rhdf5lib::pkgconfig
 RHDF5_LIBS= $(shell "${R_HOME}/bin/Rscript" -e "Rhdf5lib::pkgconfig('PKG_CXX_LIBS')")
-PKG_LIBS =  ${boost_fs_objs} ${boost_sys_objs} $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `${R_HOME}/bin/Rscript -e "RProtoBufLib:::LdFlags()"` $(RHDF5_LIBS) `${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()"` -lws2_32  
+FSLIB = -lstdc++fs
+PKG_LIBS = -lstdc++fs ${boost_fs_objs} ${boost_sys_objs} $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `${R_HOME}/bin/Rscript -e "RProtoBufLib:::LdFlags()"` $(RHDF5_LIBS) `${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()"` -lws2_32  
 
 .PHONY: all clean 
 


### PR DESCRIPTION
Looks like the Win makevars fell behind.

---

You're currently using `std::experimental::filesystem::v1`. Unless there's a reason to use some specific library's experimental v1 implementation, it's probably better to use `std::filesystem` or `std::experimental::filesystem`, see https://stackoverflow.com/a/53365539/1218408 for example macros.