### PR TITLE
Support column addition and re-sizing for all backends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.1.14
+Version: 2.1.15
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <wjiang2@fhcrc.org>, Jake Wagner <jpwagner@fhcrc.org>

--- a/inst/include/cytolib/CytoFrame.hpp
+++ b/inst/include/cytolib/CytoFrame.hpp
@@ -384,9 +384,13 @@ public:
 
 	/**
 	 * Add named columns to the data. This will also appropriately update some keywords and params.
-	 * Currently only implemented for MemCytoFrame
 	 */
-	virtual void append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols)=0;
+	void append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols);
+
+	/**
+	 * Append columns to data matrix. Necessary re-sizing is handled by set_data for each backend.
+	 */
+	virtual void append_data_columns(const EVENT_DATA_VEC & new_cols)=0;
 
 	/**
 	 * get all the marker names

--- a/inst/include/cytolib/CytoFrameView.hpp
+++ b/inst/include/cytolib/CytoFrameView.hpp
@@ -107,9 +107,18 @@ public:
 		return get_cytoframe_ptr()->set_channels(old);
 	}
 
+	// Realize the view to the underlying cytoframe (if necessary) and then append extra columns.
+	// Realizing the view is necessary for unambiguous Pn indices for the added columns.
 	void append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols){
-		// Need to deal with potentially different indices if this is a subview
-		get_cytoframe_ptr()->append_columns(new_colnames, new_cols);
+		CytoFramePtr ptr;
+		if(is_row_indexed() || is_col_indexed()){
+			// Realize to the original file
+			ptr = realize(get_cytoframe_ptr(), get_uri(), true);
+			reset_view();
+		}else{
+			ptr = get_cytoframe_ptr();
+		}
+		ptr->append_columns(new_colnames, new_cols);
 	}
 
 	string get_marker(const string & channel)

--- a/inst/include/cytolib/H5CytoFrame.hpp
+++ b/inst/include/cytolib/H5CytoFrame.hpp
@@ -141,8 +141,11 @@ public:
 		return res;
 	}
 
-	void append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols){
-		throw(domain_error("append_columns not implemented for H5CytoFrame!"));
+	void append_data_columns(const EVENT_DATA_VEC & new_cols)
+	{
+		EVENT_DATA_VEC this_data = get_data();
+		this_data.insert_cols(this_data.n_cols, new_cols);
+		set_data(this_data);
 	}
 
 	void set_marker(const string & channelname, const string & markername)

--- a/inst/include/cytolib/MemCytoFrame.hpp
+++ b/inst/include/cytolib/MemCytoFrame.hpp
@@ -184,7 +184,7 @@ public:
 		return "";
 	}
 
-	void append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols);
+	void append_data_columns(const EVENT_DATA_VEC & new_cols);
 
 };
 

--- a/src/H5CytoFrame.cpp
+++ b/src/H5CytoFrame.cpp
@@ -243,6 +243,11 @@ namespace cytolib
 		H5File file(filename_, h5_flags(), FileCreatPropList::DEFAULT, access_plist_);
 		check_write_permission();
 		hsize_t dims_data[2] = {_data.n_cols, _data.n_rows};
+
+		// For the case that the data matrix has been re-sized
+		dims[0] = _data.n_cols;
+		dims[1] = _data.n_rows;
+
 		auto dataset = file.openDataSet(DATASET_NAME);
 
 		dataset.extend(dims_data);

--- a/src/MemCytoFrame.cpp
+++ b/src/MemCytoFrame.cpp
@@ -1039,90 +1039,9 @@ namespace cytolib
 		}
 	}
 
-
-
-
-
-	void MemCytoFrame::append_columns(const vector<string> & new_colnames, const EVENT_DATA_VEC & new_cols){
-		// Pre-checks
-
-		// Size checks
-		if( new_colnames.size() <= 0 | (new_colnames.size() != new_cols.n_cols))
-			throw(domain_error("Must have equal (nonzero) number of new column names and columns."));
-		if( new_cols.n_rows != data_.n_rows)
-			throw(domain_error("New columns must have same number of rows as existing columns."));
-
-		// Check validity of new channel names
-
-		// Check if new channel names duplicate any existing channels
-		vector<string> existing_channels = get_channels();
-		for(auto & name : new_colnames){
-			if(name.empty())
-				throw(domain_error("Channel names must be non-empty strings"));
-			if(get_col_idx(name, ColType::channel) != -1)
-				throw(domain_error("CytoFrame already contains this channel: " + name));
-		}
-		// Check for duplicates within the new colnames
-		vector<string> check_names(new_colnames.size());
-		std::copy(new_colnames.begin(), new_colnames.end(), check_names.begin());
-		std::sort(check_names.begin(), check_names.end());
-		if(std::unique(check_names.begin(), check_names.end()) != check_names.end())
-			throw(domain_error("Duplicate new channel names detected. New channel names must be unique."));
-
-		unsigned num_toadd = new_cols.n_cols;
-
-		// arma::min/max for column ranges
-		rowvec new_mins = min(new_cols, 0);
-		rowvec new_maxs = max(new_cols, 0);
-
-		// If ALL are good, go ahead and add them to the params with empty marker names
-		for(unsigned i = 0; i < num_toadd; i++){
-			cytoParam to_add;
-			to_add.channel = new_colnames[i];
-			to_add.marker = "";
-			to_add.min = new_mins(i);
-			to_add.max = new_maxs(i);
-			to_add.PnG = 1;
-			to_add.PnE[0] = to_add.PnE[1] = 0.0;
-			to_add.PnB = 32;
-			params.push_back(to_add);
-		}
-		build_hash();
-
-		// By the logic of CytoframeView::get_original_col_ids
-		// we should assume we assign the new indices starting right after data_.n_cols
-		vector<unsigned> new_idx(num_toadd);
-		for(unsigned i = 0, j = data_.n_cols+1; i < num_toadd; i++, j++)
-			new_idx[i] = j;
-
-		// Add new columns to end of data matrix
+	void MemCytoFrame::append_data_columns(const EVENT_DATA_VEC & new_cols)
+	{
 		data_.insert_cols(data_.n_cols, new_cols);
-
-		// Update keywords
-
-		// Some logic adapted from MemCytoFrame::read_fcs_header
-		KEY_WORDS::iterator it;
-		for(unsigned i = 0; i < num_toadd; i++){
-			string pid = to_string(new_idx[i]);
-			string range_str;
-
-			// Defaults that will be set through logic of old cf_append_cols
-			keys_["$P" + pid + "B"] = "32";
-			keys_["$P" + pid + "E"] = "0,0";
-			// PnG key not set to match old behavior
-
-			// Bump by 1, following logic of flowCore#187 and flowCore@654f0c3
-			keys_["$P" + pid + "R"] = to_string(int(ceil(new_maxs(i))) + 1);
-
-
-			if( keys_.find("transformation")!=keys_.end() &&  keys_["transformation"] == "custom"){
-				keys_["flowCore_$P" + pid + "Rmin"] = to_string(new_mins(i));
-				keys_["flowCore_$P" + pid + "Rmax"] = to_string(new_maxs(i));
-			}
-
-			keys_["$P" + pid + "N"] = new_colnames[i];
-		}
-
 	}
 
 


### PR DESCRIPTION
@mikejiang , I'm making this a PR so you can look it over if you want before the merge as you have done the bulk of the work on TileCytoFrame.

The key changes here are:

1. Pushing the `append_columns` logic up to the `CytoFrameView` and `CytoFrame` classes so it can be generalized using virtual accessors and mutators for the particular `CytoFrame` backends.
2. Making `write_tile_data` and `write_tile_params` handle any necessary `tiledb::Array` re-sizing for themselves to keep that logic modular.
3. Some minor tweaks to `TileCytoFrame::set_data` so re-sizing will be visible by later `get_data` calls.

I have verified that all of the following tests pass:

- All `flowCore` tests
- All `flowWorkspace` tests for all backends, except for some for which I don't have access to necessary files (the [s3-gs tests](https://github.com/RGLab/flowWorkspace/blob/master/tests/testthat/s3-gs.R)), so I'd appreciate if you could check those quickly as well.
- All `CytoML` tests
- All `openCyto` tests

Additionally, this now looks good with my demonstration test script from https://github.com/RGLab/openCyto/issues/214, just slightly adapted to show that the original `cytoframe`s are now changed so re-assignment of the `lapply` output is no longer necessary.

```
> library(flowCore)
> library(flowWorkspace)
> 
> for(backend in c("mem", "h5", "tile")){
+     cs <- load_cytoset_from_fcs(list.files(system.file("extdata", package = "flowWorkspaceData"), pattern = "CytoTrol", full.names = TRUE), backend = backend)
+     print("**********")
+     print(paste0("** ", backend, " Pre**"))
+     cs[[1]]
+     print("Backend:")
+     print(flowWorkspace:::cf_backend_type(cs[[1]]))
+     print(cf_get_uri(cs[[1]]))
+     print("pData:")
+     print(pData(cs))
+     print("exprs:")
+     print(head(exprs(cs[[1]])))
+     
+     # cf_append_cols now operates on the original cytoframes
+     # so there is no need to catch the results here
+     lapply(cs, function(cf){
+         existing_subset <- exprs(cf)[,c("B710-A", "R660-A")]
+         derived_col <- existing_subset[,"B710-A"]/existing_subset[,"R660-A"]
+         derived_col <- matrix(derived_col, ncol = 1)
+         colnames(derived_col) <- "ratio_B710_R660"
+         cf_append_cols(cf, derived_col)
+     })
+     print(paste0("** ", backend, " Post**"))
+     cs[[1]]
+     print("Backend:")
+     print(flowWorkspace:::cf_backend_type(cs[[1]]))
+     print(cf_get_uri(cs[[1]]))
+     print("pData:")
+     print(pData(cs))
+     print("exprs:")
+     print(head(exprs(cs[[1]])))
+     print("**********")
+ }
[1] "**********"
[1] "** mem Pre**"
[1] "Backend:"
[1] "mem"
[1] ""
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7
[1] "** mem Post**"
[1] "Backend:"
[1] "mem"
[1] ""
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time ratio_B710_R660
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2      0.62714178
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4      0.01125176
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6      0.43596910
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6      0.26345332
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7      1.11983732
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7     13.10914649
[1] "**********"
[1] "**********"
[1] "** h5 Pre**"
[1] "Backend:"
[1] "h5"
[1] "/tmp/Rtmpcqx72E/898d060a-7284-4f3b-b690-1b3635f41947/CytoTrol_CytoTrol_1.fcs.h5"
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7
[1] "** h5 Post**"
[1] "Backend:"
[1] "h5"
[1] "/tmp/Rtmpcqx72E/898d060a-7284-4f3b-b690-1b3635f41947/CytoTrol_CytoTrol_1.fcs.h5"
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time ratio_B710_R660
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2      0.62714177
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4      0.01125176
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6      0.43596908
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6      0.26345333
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7      1.11983728
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7     13.10914612
[1] "**********"
[1] "**********"
[1] "** tile Pre**"
[1] "Backend:"
[1] "tile"
[1] "/tmp/Rtmpcqx72E/94d9d80a-ff02-4436-a34e-ae57fe19dd5b/CytoTrol_CytoTrol_1.fcs.tile"
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7
[1] "** tile Post**"
[1] "Backend:"
[1] "tile"
[1] "/tmp/Rtmpcqx72E/94d9d80a-ff02-4436-a34e-ae57fe19dd5b/CytoTrol_CytoTrol_1.fcs.tile"
[1] "pData:"
                                           name
CytoTrol_CytoTrol_1.fcs CytoTrol_CytoTrol_1.fcs
CytoTrol_CytoTrol_2.fcs CytoTrol_CytoTrol_2.fcs
[1] "exprs:"
         FSC-A  FSC-H    FSC-W     SSC-A   B710-A   R660-A    R780-A    V450-A   V545-A   G560-A   G780-A Time ratio_B710_R660
[1,] 140733.05 133376 69150.98  91113.96 22311.24 35576.07  14302.16 16232.649  7644.65  4113.60 12672.00  0.2      0.62714177
[2,]  26195.32  26207 65506.79  10115.28     5.04   447.93    682.56    43.700    77.90   -91.20    18.24  0.4      0.01125176
[3,]  64294.02  51594 81667.89 174620.03   371.28   851.62    -66.36   335.350   971.85   273.60   271.68  0.6      0.43596908
[4,] 128393.87 103613 81210.08 150625.44  1494.36  5672.20   2979.09  1492.450 28790.70   771.84   988.80  0.6      0.26345333
[5,] 127717.88 119616 69974.92  76954.91  2545.20  2272.83 124635.93  8608.899  4190.45 14306.88 58977.60  0.7      1.11983728
[6,] 134347.02 125651 70071.60  70116.48 23052.96  1758.54   5281.15  4849.750  2859.50  2249.28  1560.96  0.7     13.10914612
[1] "**********"
```

There will be an accompanying (albeit much simpler PR for `flowWorkspace`)
