### PR TITLE
Synchronize flowCore_PnRmax handling between cytolib and flowCore FCS parsers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.1.18
+Version: 2.1.19
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <wjiang2@fhcrc.org>, Jake Wagner <jpwagner@fhcrc.org>

--- a/inst/include/cytolib/MemCytoFrame.hpp
+++ b/inst/include/cytolib/MemCytoFrame.hpp
@@ -10,6 +10,7 @@
 #ifndef INST_INCLUDE_CYTOLIB_MEMCYTOFRAME_HPP_
 #define INST_INCLUDE_CYTOLIB_MEMCYTOFRAME_HPP_
 #include "CytoFrame.hpp"
+#include "trans_group.hpp"
 #include "readFCSdata.hpp"
 
 namespace cytolib
@@ -186,6 +187,7 @@ public:
 
 	void append_data_columns(const EVENT_DATA_VEC & new_cols);
 
+	void transform_data(const trans_local & trans);
 };
 
 

--- a/src/GatingHierarchy.cpp
+++ b/src/GatingHierarchy.cpp
@@ -173,7 +173,7 @@ namespace cytolib
 				curTrans->transforming(&param_range.second, 1);
 			}
 
-
+			cytoframe.set_keyword("transformation", "custom");
 			cytoframe.set_range(curChannel, ColType::channel, param_range);
 
 		}

--- a/src/MemCytoFrame.cpp
+++ b/src/MemCytoFrame.cpp
@@ -926,12 +926,12 @@ namespace cytolib
 		for(int i = 1; i <= nrpar; i++)
 		{
 			string pid = to_string(i);
-			string range_str = "flowCore_$P" + pid + "Rmax";
-			it = keys_.find(range_str);
-			if( it==keys_.end() ){
+			string range_str;
+			if( keys_.find("transformation")!=keys_.end() &&  keys_["transformation"] == "custom")
+				range_str = "flowCore_$P" + pid + "Rmax";
+			else
 				range_str = "$P" + pid + "R";
-				it = keys_.find(range_str);
-			}
+			it = keys_.find(range_str);
 			if(it==keys_.end())
 				throw(domain_error(range_str + " not contained in Text section!"));
 			else

--- a/src/MemCytoFrame.cpp
+++ b/src/MemCytoFrame.cpp
@@ -926,12 +926,12 @@ namespace cytolib
 		for(int i = 1; i <= nrpar; i++)
 		{
 			string pid = to_string(i);
-			string range_str;
-			if( keys_.find("transformation")!=keys_.end() &&  keys_["transformation"] == "custom")
-				range_str = "flowCore_$P" + pid + "Rmax";
-			else
-				range_str = "$P" + pid + "R";
+			string range_str = "flowCore_$P" + pid + "Rmax";
 			it = keys_.find(range_str);
+			if( it==keys_.end() ){
+				range_str = "$P" + pid + "R";
+				it = keys_.find(range_str);
+			}
 			if(it==keys_.end())
 				throw(domain_error(range_str + " not contained in Text section!"));
 			else

--- a/src/MemCytoFrame.cpp
+++ b/src/MemCytoFrame.cpp
@@ -928,15 +928,16 @@ namespace cytolib
 			string pid = to_string(i);
 			string range_str = "flowCore_$P" + pid + "Rmax";
 			it = keys_.find(range_str);
-			if( it==keys_.end() ){
+			if( !(it == keys_.end())){
+				params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second) + 1;
+			}else{
 				range_str = "$P" + pid + "R";
 				it = keys_.find(range_str);
+				if(it==keys_.end())
+					throw(domain_error(range_str + " not contained in Text section!"));
+				else
+					params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second);
 			}
-			if(it==keys_.end())
-				throw(domain_error(range_str + " not contained in Text section!"));
-			else
-				params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second);
-
 
 			params[i-1].PnB = stoi(keys_["$P" + pid + "B"]);
 

--- a/src/MemCytoFrame.cpp
+++ b/src/MemCytoFrame.cpp
@@ -928,16 +928,15 @@ namespace cytolib
 			string pid = to_string(i);
 			string range_str = "flowCore_$P" + pid + "Rmax";
 			it = keys_.find(range_str);
-			if( !(it == keys_.end())){
-				params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second) + 1;
-			}else{
+			if( it==keys_.end() ){
 				range_str = "$P" + pid + "R";
 				it = keys_.find(range_str);
-				if(it==keys_.end())
-					throw(domain_error(range_str + " not contained in Text section!"));
-				else
-					params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second);
 			}
+			if(it==keys_.end())
+				throw(domain_error(range_str + " not contained in Text section!"));
+			else
+				params[i-1].max = boost::lexical_cast<EVENT_DATA_TYPE>(it->second);
+
 
 			params[i-1].PnB = stoi(keys_["$P" + pid + "B"]);
 


### PR DESCRIPTION
See https://github.com/RGLab/flowWorkspace/issues/348 for discussion of the different `flowCore` and `cytolib` handling of `flowCore_PnRmax` values in the FCS keywords. This commit is intended to rectify that, but because it involves a low-level change in the parser I thought it might be good to allow review/veto before merging it in. After this commit, all `flowCore`, `flowWorkspace`, and `CytoML` tests (including internal) still pass, but the handling of instrument range is now more consistent between `flowFrame` and `cytoframe`:

```
> library(flowCore)
> library(flowWorkspace)
As part of improvements to flowWorkspace, some behavior of
GatingSet objects has changed. For details, please read the section
titled "The cytoframe and cytoset classes" in the package vignette:

  vignette("flowWorkspace-Introduction", "flowWorkspace")
> library(CytoExploreRData)
> 
> gs <- load_gs(system.file("extdata/Activation-GatingSet", package = "CytoExploreRData"),
+               backend_readonly = FALSE)
> 
> cf <- gh_pop_get_data(gs[[1]])
> 
> range(cf, "data")
       FSC-A  FSC-H    FSC-W     SSC-A  SSC-H     SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min   3840.9   5008  48962.7    812.43    992  48231.07        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143.0 258475 213015.5 262143.00 257528 240257.84         4.4974089  4.4947143      4.1895137  4.4887066  4.344767
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219 -0.748190   54.7
max          4.499980          4.499548  4.4908552         4.4999361          4.408533  4.378348 6312.3
> range(cf, "instrument")
     FSC-A  FSC-H  FSC-W  SSC-A  SSC-H  SSC-W Alexa Fluor 488-A      PE-A PE-Texas Red-A   7-AAD-A  PE-Cy7-A Alexa Fluor 405-A
min      0      0      0      0      0      0         0.3440274 0.5447587      0.7766721 0.7676063 0.7410693         0.2184961
max 262143 262143 262143 262143 262143 262143         4.5000000 4.5000000      4.5000000 4.5000000 4.5000000         4.5000000
    Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min        -0.1468131  0.3265916         0.3060549         0.5694999 0.5042382      0
max         4.5000000  4.5000000         4.5000000         4.5000000 4.5000000 262143
> parameters(cf)$maxRange
 [1] 262143.0 262143.0 262143.0 262143.0 262143.0 262143.0      4.5      4.5      4.5      4.5      4.5      4.5      4.5
[14]      4.5      4.5      4.5      4.5 262143.0
> 
> fr <- cytoframe_to_flowFrame(cf)
> range(fr, "data")
       FSC-A  FSC-H    FSC-W     SSC-A  SSC-H     SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min   3840.9   5008  48962.7    812.43    992  48231.07        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143.0 258475 213015.5 262143.00 257528 240257.84         4.4974089  4.4947143      4.1895137  4.4887066  4.344767
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219 -0.748190   54.7
max          4.499980          4.499548  4.4908552         4.4999361          4.408533  4.378348 6312.3
> range(fr, "instrument")
     FSC-A  FSC-H  FSC-W  SSC-A  SSC-H  SSC-W Alexa Fluor 488-A      PE-A PE-Texas Red-A   7-AAD-A  PE-Cy7-A Alexa Fluor 405-A
min      0      0      0      0      0      0         0.3440274 0.5447587      0.7766721 0.7676063 0.7410693         0.2184961
max 262143 262143 262143 262143 262143 262143         4.5000000 4.5000000      4.5000000 4.5000000 4.5000000         4.5000000
    Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min        -0.1468131  0.3265916         0.3060549         0.5694999 0.5042382      0
max         4.5000000  4.5000000         4.5000000         4.5000000 4.5000000 262143
> parameters(fr)$maxRange
 [1] 262143.0 262143.0 262143.0 262143.0 262143.0 262143.0      4.5      4.5      4.5      4.5      4.5      4.5      4.5
[14]      4.5      4.5      4.5      4.5 262143.0
> 
> cf_back <- flowFrame_to_cytoframe(fr)
> range(cf_back, "data")
       FSC-A  FSC-H    FSC-W     SSC-A  SSC-H     SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min   3840.9   5008  48962.7    812.43    992  48231.07        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143.0 258475 213015.5 262143.00 257528 240257.84         4.4974089  4.4947143      4.1895137  4.4887066  4.344767
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219 -0.748190   54.7
max          4.499980          4.499548  4.4908552         4.4999361          4.408533  4.378348 6312.3
> range(cf_back, "instrument")
     FSC-A  FSC-H  FSC-W  SSC-A  SSC-H  SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min      0      0      0      0      0      0        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143 262143 262143 262143 262143 262143         4.5000000  4.5000000      4.5000000  4.5000000  4.500000
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219  -0.74819      0
max          4.500000          4.500000  4.5000000         4.5000000          4.500000   4.50000 262143
> parameters(cf_back)$maxRange
 [1] 262143.0 262143.0 262143.0 262143.0 262143.0 262143.0      4.5      4.5      4.5      4.5      4.5      4.5      4.5
[14]      4.5      4.5      4.5      4.5 262143.0
> 
> tmp <- tempfile()
> write.FCS(fr, tmp)
[1] "/tmp/RtmpCBmJwt/file69d062238d6c"
> fr_back <- read.FCS(tmp)
> range(fr_back, "data")
       FSC-A  FSC-H    FSC-W     SSC-A  SSC-H     SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min   3840.9   5008  48962.7    812.43    992  48231.07        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143.0 258475 213015.5 262143.00 257528 240257.84         4.4974089  4.4947143      4.1895137  4.4887066  4.344767
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219 -0.748190   54.7
max          4.499980          4.499548  4.4908552         4.4999361          4.408533  4.378348 6312.3
> range(fr_back, "instrument")
     FSC-A  FSC-H  FSC-W  SSC-A  SSC-H  SSC-W Alexa Fluor 488-A       PE-A PE-Texas Red-A    7-AAD-A  PE-Cy7-A
min      0      0      0      0      0      0        -0.9284211 -0.2008877     -0.4126023 -0.2468764 -1.286891
max 262143 262143 262143 262143 262143 262143         4.5000000  4.5000000      4.5000000  4.5000000  4.500000
    Alexa Fluor 405-A Alexa Fluor 430-A Qdot 605-A Alexa Fluor 647-A Alexa Fluor 700-A APC-Cy7-A   Time
min         -1.011764         -1.249842 -0.7027928        -0.1020277         -1.193219  -0.74819      0
max          4.500000          4.500000  4.5000000         4.5000000          4.500000   4.50000 262143
> parameters(fr_back)$maxRange
 [1] 262143.0 262143.0 262143.0 262143.0 262143.0 262143.0      4.5      4.5      4.5      4.5      4.5      4.5      4.5
[14]      4.5      4.5      4.5      4.5 262143.0
```