### PR TITLE
Add extra methods for manipulating keywords without full replacement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.1.19
+Version: 2.1.20
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <wjiang2@fhcrc.org>, Jake Wagner <jpwagner@fhcrc.org>

--- a/inst/include/cytolib/CytoFrame.hpp
+++ b/inst/include/cytolib/CytoFrame.hpp
@@ -246,6 +246,31 @@ public:
 	}
 
 	/**
+	 * Change the key of a single key-value pair
+	 * @param old_key old keyword name
+	 * @param new_key new keyword name
+	 */
+	virtual void rename_keyword(const string & old_key, const string & new_key)
+	{
+		KW_PAIR::iterator it = keys_.find(old_key);
+        if(it!=keys_.end())
+        	it->first = new_key;
+        else
+        	throw(domain_error("keyword not found: " + old_key));
+	}
+
+	/**
+	 *	Remove a single key-value pair.
+	 *	KW_PAIR is vector based, so this is not particularly efficient
+	 *	as later elements will need to be relocated, but it is faster
+	 *	than completely reconstructing the KW_PAIR object.
+	 *	@param key keyword to be removed
+	 */
+	virtual void remove_keyword(const string & key){
+		keys_.erase(key);
+	}
+
+	/**
 	 * get the number of columns(or parameters)
 	 *
 	 * @return

--- a/inst/include/cytolib/CytoFrameView.hpp
+++ b/inst/include/cytolib/CytoFrameView.hpp
@@ -186,6 +186,12 @@ public:
 		get_cytoframe_ptr()->set_keywords(keys);
 	}
 
+	void rename_keyword(const string & old_key, const string & new_key){
+		get_cytoframe_ptr()->rename_keyword(old_key, new_key);
+	}
+	void remove_keyword(const string & key){
+		get_cytoframe_ptr()->remove_keyword(key);
+	}
 	void set_range(const string & colname, ColType ctype, pair<EVENT_DATA_TYPE, EVENT_DATA_TYPE> new_range){
 		get_cytoframe_ptr()->set_range(colname, ctype, new_range);
 	}

--- a/inst/include/cytolib/H5CytoFrame.hpp
+++ b/inst/include/cytolib/H5CytoFrame.hpp
@@ -126,6 +126,14 @@ public:
 		is_dirty_keys = true;
 
 	}
+	void rename_keyword(const string & old_key, const string & new_key){
+		CytoFrame::rename_keyword(old_key, new_key);
+		is_dirty_keys = true;
+	}
+	void remove_keyword(const string & key){
+		CytoFrame::remove_keyword(key);
+		is_dirty_keys = true;
+	}
 	void set_channel(const string & oldname, const string &newname, bool is_update_keywords = true)
 	{
 		CytoFrame::set_channel(oldname, newname, is_update_keywords);

--- a/inst/include/cytolib/TileCytoFrame.hpp
+++ b/inst/include/cytolib/TileCytoFrame.hpp
@@ -104,6 +104,14 @@ public:
 		is_dirty_keys = true;
 
 	}
+	void rename_keyword(const string & old_key, const string & new_key){
+		CytoFrame::rename_keyword(old_key, new_key);
+		is_dirty_keys = true;
+	}
+	void remove_keyword(const string & key){
+		CytoFrame::remove_keyword(key);
+		is_dirty_keys = true;
+	}
 	void set_channel(const string & oldname, const string &newname, bool is_update_keywords = true)
 	{
 		CytoFrame::set_channel(oldname, newname, is_update_keywords);

--- a/inst/include/cytolib/readFCSHeader.hpp
+++ b/inst/include/cytolib/readFCSHeader.hpp
@@ -74,6 +74,13 @@ public:
  pair <string, string> & operator [](const int & n){
 	 return kw[n];
  }
+ void erase(const string & key){
+	 iterator it = find(key);
+     if(it!=end())
+     	kw.erase(it);
+     else
+     	throw(domain_error("keyword not found: " + key));
+ };
 };
 
 


### PR DESCRIPTION
These changes are just to expose more direct capability to manipulate individual key-value pairs in `CytoFrame` keywords in support of changes in the `cf_keyword_` functions in `flowWorkspace`.