### PR TITLE
avoid graph traversing when full path is requested for getNodePaths()

### DIFF
--- a/src/GatingHierarchy.cpp
+++ b/src/GatingHierarchy.cpp
@@ -1432,7 +1432,8 @@ namespace cytolib
 		nodePath.push_front(sNodePath);
 
 		//init searching routes
-		VertexID_vec leafIDs=getDescendants(0,leafName);
+		VertexID_vec leafIDs;
+		if (!fullPath) leafIDs = getDescendants(0, leafName);//only invoke getDescendants call when non-full-path is requested since it gets expensive for large tree
 
 		//start to trace back to ancestors
 		while(u > 0)


### PR DESCRIPTION
The underlying boost graph traversing (triggered by searching unique shortest path) becomes the bottleneck when gating tree grows to 10k size. So we want to disable it when the simple full path is requested.

This patch impacts https://github.com/RGLab/flowWorkspace/pull/364 as well