### PR TITLE
Fixed logical gate compute

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,133 +1,45 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-#
-
-name: build
-
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [ release, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ release, master ]
+    branches: [main, master]
+
+name: R-CMD-check
 
 jobs:
-  build:
+  R-CMD-check:
     runs-on: ${{ matrix.config.os }}
-    name: ${{ matrix.config.os }} (${{ matrix.r }})
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
     strategy:
       fail-fast: false
       matrix:
-        r: ['release', 'devel']
         config:
-#           - {os: windows-latest, suffix: 'zip'}
-          - {os: macOS-latest, suffix: 'tgz'}
-#           - {os: ubuntu-16.04, suffix: 'tar.gz', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-        isMaster:
-          - ${{ contains(github.ref, 'master') }}
-        exclude:
-          - isMaster: false
-            r: devel
-          - isMaster: true
-            r: release
+          - {os: macOS-latest,   r: 'release'}
+
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-    
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up R ${{ matrix.r }}
-        uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.r }}
+          r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-      
-      - name: set token for cytoinstaller(and remotes) to increase github API rate limit
-        env:
-          SUPER_SECRET: ${{ secrets.CYTOINSTALLER_TOKEN }}
-        run: echo "GITHUB_TOKEN=$SUPER_SECRET" >> $GITHUB_ENV
- 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-        
-      - name: Get bioc ver
-        run: echo "bioc_ver=$(Rscript -e 'writeLines(as.character(remotes::bioc_version()))')" >> $GITHUB_ENV
-        shell: bash
-        
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: check bioc ver
-        run: echo $bioc_ver
-        shell: bash
-        
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "16.04"))')
-          sudo apt-get install -y libcurl4-openssl-dev
-    
-      - name: Install system dependencies (mac)
-        if: runner.os == 'macOS'
-        run: |
-          brew install libgit2
-          
-      - name: Install dependencies
-        run: |
-          remotes::install_cran(c("rcmdcheck", "devtools"))
-          remotes::install_github("RGLab/cytoinstaller")
-          cytoinstaller::cyto_install_deps(dependencies = TRUE)
-        shell: Rscript {0}
-
-      - name: check rate limit
-        run: |
-          gh::gh("GET /rate_limit")$resources$core$remaining
-        shell: Rscript {0}
-# the same build error from bioc devel        
-#       - name: Check
-#         env:
-#           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-#         run: rcmdcheck::rcmdcheck(args = c("--no-manual"), check_dir = "check")
-#         shell: Rscript {0}
-
-#       - name: Upload check results
-#         if: failure()
-#         uses: actions/upload-artifact@main
-#         with:
-#           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-#           path: check
-          
-      - name: build src pkg
-        if: runner.os == 'Linux'
-        run: devtools::build()
-        shell: Rscript {0}
-        
-      - name: build bin pkg
-        if: runner.os != 'Linux'
-        run: devtools::build(binary = TRUE)
-        shell: Rscript {0}  
-        
-      - name: Upload Release Asset
-        uses: svenstaro/upload-release-action@v2
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '../*.${{ matrix.config.suffix }}'
-          file_glob: true
-          tag: bioc_${{ env.bioc_ver}}
-          overwrite: true
-          body: "This is my release text"
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.9.0
+Version: 2.9.1
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <mike@ozette.ai>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.8.0
+Version: 2.9.0
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <mike@ozette.ai>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cytolib
 Type: Package
 Title: C++ infrastructure for representing and interacting with the gated cytometry data
-Version: 2.7.4
+Version: 2.8.0
 Date: 2017-08-07
 Author: Mike Jiang
 Maintainer: Mike Jiang <mike@ozette.ai>

--- a/src/GatingHierarchy.cpp
+++ b/src/GatingHierarchy.cpp
@@ -233,12 +233,12 @@ namespace cytolib
 			}
 		case LOGICALGATE://skip any gating operation since the indice is already set once the gate is added
 		case CLUSTERGATE:{
-		  auto curIndices = getIndices(u);
+		  auto curIndices = node.getIndices();
 		  std::transform(curIndices.begin(), curIndices.end(),
                    parentIndice.getIndices().begin(), curIndices.begin(),
                    std::logical_and<bool>());
 		  
-		  node.setIndices(u, curIndices);
+		  node.setIndices(curIndices);
 		  node.computeStats();
 		}
 			

--- a/src/GatingHierarchy.cpp
+++ b/src/GatingHierarchy.cpp
@@ -232,8 +232,16 @@ namespace cytolib
 				break;
 			}
 		case LOGICALGATE://skip any gating operation since the indice is already set once the gate is added
-		case CLUSTERGATE:
-			node.computeStats();
+		case CLUSTERGATE:{
+		  auto curIndices = getIndices(u);
+		  std::transform(curIndices.begin(), curIndices.end(),
+                   parentIndice.getIndices().begin(), curIndices.begin(),
+                   std::logical_and<bool>());
+		  
+		  node.setIndices(u, curIndices);
+		  node.computeStats();
+		}
+			
 			return;
 		default:
 			{


### PR DESCRIPTION
It is a bug triggered by the edge case of updating the existing logical gate 

Basically it happens when the upstream gate (e.g. time gate) is updated by setting the new indices(i.e. `flowWorkspace::gh_pop_set_indices`) , then its child  gate, which is a logical gate as well, did not get recomputed, which cause all its downstream gates failed to update.

