### PR TITLE
Update BH requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
 Depends:
     R (>= 3.4)
 Suggests: knitr, rmarkdown
-LinkingTo: BH(>= 1.75.0.0), RProtoBufLib(>= 2.3.5),Rhdf5lib
+LinkingTo: BH(>= 1.81.0.0), RProtoBufLib(>= 2.3.5),Rhdf5lib
 biocViews: ImmunoOncology, FlowCytometry, DataImport, Preprocessing, DataRepresentation
 VignetteBuilder: knitr
 SystemRequirements: GNU make, C++11


### PR DESCRIPTION
Right now in an environment where `BH 1.78` is pre-installed,  with `Bioc 3.16` running `BiocManager::install('cytolib')` with version `cytolib 2.10.1`, results in 
```
g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DROUT -I../inst/include -DBOOST_NO_AUTO_PTR -DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF -DBOOST_FILESYSTEM_SINGLE_THREADED  -I'/usr/local/lib/R/site-library/BH/include' -I'/tmp/tmp/built/RProtoBufLib/include' -I'/tmp/tmp/built/Rhdf5lib/include'    -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-ZLat0n/r-base-4.2.2.20221110=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c boost/libs/filesystem/src/path_traits.cpp -o boost/libs/filesystem/src/path_traits.o
boost/libs/filesystem/src/path_traits.cpp:15:10: fatal error: boost/filesystem/detail/path_traits.hpp: No such file or directory
   15 | #include <boost/filesystem/detail/path_traits.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [/usr/lib/R/etc/Makeconf:178: boost/libs/filesystem/src/path_traits.o] Error 1
```

This can be fixed by manually updating `BH` to `1.81`, hence why I think the requirement change is called for, and it should likely be made on 3_16 git.bioc branch imho.


(tangentially would also encourage you to rename your main branch to `devel` over `master`)